### PR TITLE
Cleanup CloudFormation Templates, and add deployment script.

### DIFF
--- a/cfn/cloudfront-s3-website.json
+++ b/cfn/cloudfront-s3-website.json
@@ -221,7 +221,20 @@
           ]
         },
         "Name": {
-          "Ref": "Subdomain"
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "Subdomain"
+              },
+              ".",
+              {
+                "Ref": "Domain"
+              },
+              "."
+            ]
+          ]
+
         },
         "ResourceRecords": [
           {

--- a/cfn/cloudfront-s3-website.json
+++ b/cfn/cloudfront-s3-website.json
@@ -34,12 +34,10 @@
   "Mappings": {
     "DomainAWSResourceIdMap": {
       "aptible.com": {
-        "IamCertificateId": "ASCAIIHAG2U3A2CIAFOSU",
-        "HostedZoneName": "aptible.com."
+        "IamCertificateId": "ASCAIIHAG2U3A2CIAFOSU"
       },
       "aptible-staging.com": {
-        "IamCertificateId": "ASCAIWRPADW2NPHDICMCA",
-        "HostedZoneName": "aptible-staging.com."
+        "IamCertificateId": "ASCAIWRPADW2NPHDICMCA"
       }
     }
   },
@@ -206,12 +204,14 @@
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {
-          "Fn::FindInMap": [
-            "DomainAWSResourceIdMap",
-            {
-              "Ref": "Domain"
-            },
-            "HostedZoneName"
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "Domain"
+              },
+              "."
+            ]
           ]
         },
         "Name": {

--- a/cfn/cloudfront-s3-website.json
+++ b/cfn/cloudfront-s3-website.json
@@ -157,15 +157,21 @@
               },
               "DomainName": {
                 "Fn::Join": [
-                  ".",
+                  "",
                   [
                     {
                       "Ref": "Subdomain"
                     },
+                    ".",
                     {
                       "Ref": "Domain"
                     },
-                    "s3-website-us-east-1.amazonaws.com"
+                    ".",
+                    "s3-website-",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
                   ]
                 ]
               },

--- a/cfn/s3-website.json
+++ b/cfn/s3-website.json
@@ -1,0 +1,135 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Template for an S3 website distribution for deployment using ember-cli-s3-deploy and ember-deploy-s3-static-index.",
+  "Parameters": {
+    "Domain": {
+      "Type": "String",
+      "Default": "aptible-staging.com",
+      "AllowedValues": [
+        "aptible.com",
+        "aptible-staging.com"
+      ],
+      "Description": "Second-level domain (e.g., aptible-staging.com) for CloudFront distribution CNAME."
+    },
+    "Subdomain": {
+      "Type": "String",
+      "Description": "Together with domain, determines CNAME at which CloudFront distribution will be served. Also determines S3 bucket name (for index/assets) and log bucket subfolder name."
+    }
+  },
+  "Mappings": {
+    "DomainAWSResourceIdMap": {
+      "aptible.com": {
+        "IamCertificateId": "ASCAIIHAG2U3A2CIAFOSU",
+        "HostedZoneName": "aptible.com."
+      },
+      "aptible-staging.com": {
+        "IamCertificateId": "ASCAIWRPADW2NPHDICMCA",
+        "HostedZoneName": "aptible-staging.com."
+      }
+    }
+  },
+  "Resources": {
+    "S3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "Private",
+        "BucketName": {
+          "Fn::Join": [
+            ".",
+            [
+              {
+                "Ref": "Subdomain"
+              },
+              {
+                "Ref": "Domain"
+              }
+            ]
+          ]
+        },
+        "WebsiteConfiguration": {
+          "IndexDocument": "index.html",
+          "RoutingRules": [
+            {
+              "RoutingRuleCondition": {
+                "HttpErrorCodeReturnedEquals": "403"
+              },
+              "RedirectRule": {
+                "HostName": {
+                  "Fn::Join": [
+                    ".",
+                    [
+                      {
+                        "Ref": "Subdomain"
+                      },
+                      {
+                        "Ref": "Domain"
+                      }
+                    ]
+                  ]
+                },
+                "Protocol": "http",
+                "ReplaceKeyPrefixWith": "#/"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "Domain"
+              },
+              "."
+            ]
+          ]
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "Subdomain"
+              },
+              ".",
+              {
+                "Ref": "Domain"
+              },
+              "."
+            ]
+          ]
+
+        },
+        "ResourceRecords": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Ref": "Subdomain"
+                },
+                ".",
+                {
+                  "Ref": "Domain"
+                },
+                ".",
+                "s3-website-",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ".amazonaws.com"
+              ]
+            ]
+          }
+        ],
+        "TTL": "300",
+        "Type": "CNAME"
+      }
+    }
+  }
+}

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,41 +1,49 @@
-module.exports = {
-  production: {
-    buildEnv: 'production',
+var SilentError = require('silent-error');
 
-    store: {
-      type: 's3-static',
-      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
-      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
-      acl: 'public-read',
-      bucket: 'dashboard.aptible.com'
-    },
-
-    assets: {
-      type: 's3',
-      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
-      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
-      acl: 'public-read',
-      bucket: 'dashboard.aptible.com'
-    }
-  },
-
-  staging: {
-    buildEnv: 'staging',
-
-    store: {
-      type: 's3-static',
-      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
-      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
-      acl: 'public-read',
-      bucket: 'dashboard.aptible-staging.com'
-    },
-
-    assets: {
-      type: 's3',
-      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
-      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
-      acl: 'public-read',
-      bucket: 'dashboard.aptible-staging.com'
-    }
-  }
+var storeBucketMap = {
+  production: 'dashboard.aptible.com',
+  development: 'dashboard.aptible-staging.com'
 };
+
+function defaultOptions() {
+}
+
+function optionsFor(environment, type) {
+  var accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
+  var secretAccessKey = process.env['AWS_SECRET_ACCESS_KEY'];
+  var bucket = process.env['AWS_BUCKET'] || storeBucketMap[environment];
+
+  if (!bucket) {
+    throw new SilentError('No bucket was found for ' + environment);
+  }
+
+  if (!accessKeyId) {
+    throw new SilentError('AWS_ACCESS_KEY_ID was not found in `process.env`. Aborting.');
+  }
+
+  if (!secretAccessKey) {
+    throw new SilentError('AWS_SECRET_ACCESS_KEY was not found in `process.env`. Aborting.');
+  }
+
+  return {
+    type: type,
+    accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
+    secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
+    acl: 'public-read',
+    bucket: bucket
+  };
+}
+
+var options = {};
+var environments = ['production', 'staging'];
+
+environments.forEach(function(environment) {
+  options[environment] = {
+    buildEnv: environment,
+
+    store: optionsFor(environment, 's3-static'),
+    assets: optionsFor(environment, 's3')
+  };
+});
+
+module.exports = options;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",
     "glob": "^4.0.5",
+    "silent-error": "^1.0.0",
     "torii": "0.3.2"
   },
   "ember-addon": {


### PR DESCRIPTION
- Build `HostedZoneName` as needed (avoid storing in the mapping).
- Remove hardcoded region from template.
- Provide fully qualified domain name for Route53.
- Refactor config/deploy.js.
  - Make a little more DRY
  - Provide helpful error messages when missing required ENV variables.
  - Allow customizing `AWS_BUCKET` (allows deployment to newly built
    CloudFormation stacks).
- Add S3 Website CloudFormation template (no CloudFront).
